### PR TITLE
Fixed the Hosting BrowserRouter option flag to be using boolean values. Added Hosting config tests

### DIFF
--- a/packages/cli/src/cli-hosting.js
+++ b/packages/cli/src/cli-hosting.js
@@ -76,7 +76,7 @@ const setup = async () => {
     .description('Configure hosting parameters')
     .option('-c, --cname <domain_name>', 'add CNAME to hosting')
     .option('-d, --remove-cname <domain_name>', 'remove CNAME from hosting')
-    .option('-b, --browser_router', 'turn on BrowserRouter support')
+    .option('-b, --browser_router <true|false>', 'turn on/off the BrowserRouter support')
     .action(async (...options) => {
       session.isAuthenticated()
       session.hasProject()

--- a/packages/cli/src/cli-hosting.js
+++ b/packages/cli/src/cli-hosting.js
@@ -76,7 +76,7 @@ const setup = async () => {
     .description('Configure hosting parameters')
     .option('-c, --cname <domain_name>', 'add CNAME to hosting')
     .option('-d, --remove-cname <domain_name>', 'remove CNAME from hosting')
-    .option('-b, --browser_router <true|false>', 'turn on/off the BrowserRouter support')
+    .option('-b, --browser-router <true|false>', 'turn on/off the BrowserRouter support')
     .action(async (...options) => {
       session.isAuthenticated()
       session.hasProject()

--- a/packages/cli/src/commands/hosting-config.js
+++ b/packages/cli/src/commands/hosting-config.js
@@ -10,7 +10,7 @@ class HostingConfig {
   }
 
   static toggleBrowserRouter (command, responses) {
-    if (responses.browser_router) return responses.browser_router
+    if (responses.browserRouter) return responses.browserRouter
 
     return command === 'true'
   }
@@ -34,14 +34,14 @@ class HostingConfig {
       }
 
       let responses = {}
-      if (!(cmd.removeCname || cmd.cname || cmd.browser_router)) {
+      if (!(cmd.removeCname || cmd.cname || cmd.browserRouter)) {
         responses = await inquirer.prompt(this.getQuestions()) || {}
       }
 
       const paramsToUpdate = {
         cname: this.cname || responses.CNAME,
         removeCNAME: cmd.removeCname,
-        browser_router: HostingConfig.toggleBrowserRouter(cmd.browser_router, responses)
+        browser_router: HostingConfig.toggleBrowserRouter(cmd.browserRouter, responses)
       }
 
       await this.hosting.configure(paramsToUpdate)

--- a/packages/cli/src/commands/hosting-config.js
+++ b/packages/cli/src/commands/hosting-config.js
@@ -9,6 +9,12 @@ class HostingConfig {
     this.hosting = null
   }
 
+  static toggleBrowserRouter (command, responses) {
+    if (responses.browser_router) return responses.browser_router
+
+    return command === 'true'
+  }
+
   async run ([hostingName, cmd]) {
     this.cname = cmd.cname
     this.fullPath = null
@@ -35,7 +41,7 @@ class HostingConfig {
       const paramsToUpdate = {
         cname: this.cname || responses.CNAME,
         removeCNAME: cmd.removeCname,
-        browser_router: cmd.browser_router || responses.browser_router
+        browser_router: HostingConfig.toggleBrowserRouter(cmd.browser_router, responses)
       }
 
       await this.hosting.configure(paramsToUpdate)

--- a/packages/cli/src/commands/hosting-config.js
+++ b/packages/cli/src/commands/hosting-config.js
@@ -2,6 +2,7 @@ import format from 'chalk'
 import inquirer from 'inquirer'
 import { p, echo, error, warning } from '../utils/print-tools'
 import Hosting from '../utils/hosting'
+import HostingListCmd from './hosting-list'
 
 class HostingConfig {
   constructor (context) {
@@ -10,8 +11,9 @@ class HostingConfig {
   }
 
   static toggleBrowserRouter (command, responses) {
-    if (responses.browserRouter) return responses.browserRouter
-
+    if (responses.browser_router) {
+      return responses.browser_router
+    }
     return command === 'true'
   }
 
@@ -45,7 +47,11 @@ class HostingConfig {
       }
 
       await this.hosting.configure(paramsToUpdate)
+
+      echo()
       echo(4)(format.green('Configuration successfully updated!'))
+      echo()
+      HostingListCmd.printHosting(this.hosting)
       echo()
     } catch (err) {
       try {

--- a/packages/cli/tests/e2e/hosting.test-e2e.js
+++ b/packages/cli/tests/e2e/hosting.test-e2e.js
@@ -86,10 +86,30 @@ describe('[E2E] CLI Hosting', function () {
       .end(done)
   })
 
-  it('can sync again local hosting', function (done) {
+  it('can sync local hosting again', function (done) {
     testNixt()
       .run(`${cliLocation} hosting sync ${hostingName}`)
       .stdout(/files synchronized/)
+      .end(done)
+  })
+
+  it('can set hosting config with prompt', function (done) {
+    testNixt()
+      .run(`${cliLocation} hosting config ${hostingName}`)
+      .on(/Set CNAME now/)
+      .respond('my.dom.ain\n')
+      .on(/Do you want to use BrowserRouter for this hosting?/)
+      .respond('Y\n')
+      .stdout(/CNAME: http:\/\/my.dom.ain/)
+      .stdout(/BrowserRouter: ✓/)
+      .end(done)
+  })
+
+  it('can set hosting config with flags', function (done) {
+    testNixt()
+      .run(`${cliLocation} hosting config ${hostingName} --browser-router false --remove-cname my.dom.ain`)
+      .stdout(/^((?!CNAME: http:\/\/my.dom.ain)[\s\S])*$/) 
+      .stdout(/BrowserRouter: x/)
       .end(done)
   })
 

--- a/packages/cli/tests/e2e/hosting.test-e2e.js
+++ b/packages/cli/tests/e2e/hosting.test-e2e.js
@@ -108,7 +108,7 @@ describe('[E2E] CLI Hosting', function () {
   it('can set hosting config with flags', function (done) {
     testNixt()
       .run(`${cliLocation} hosting config ${hostingName} --browser-router false --remove-cname my.dom.ain`)
-      .stdout(/^((?!CNAME: http:\/\/my.dom.ain)[\s\S])*$/) 
+      .stdout(/^((?!CNAME: http:\/\/my.dom.ain)[\s\S])*$/)
       .stdout(/BrowserRouter: x/)
       .end(done)
   })

--- a/packages/cli/tests/unit/utils-session.test.js
+++ b/packages/cli/tests/unit/utils-session.test.js
@@ -248,7 +248,6 @@ describe('[utils] Session', function () {
 
     describe('without parameter', function () {
       it('should print proper error message and exit process when instance does not exists', async function () {
-
         await session.checkConnection()
 
         sinon.assert.calledWith(interEcho, `Instance ${format.cyan(instanceName)} was not found on your account!`)


### PR DESCRIPTION
- Changed the BrowserRouter flag in config to be kebab cased
- It wasn't possible to turn the BrowserRouter option off with the flags. Fixed it by changing to boolean values. This is a breaking change.
- Added a stdout of the current hosting config after setting it up (previously it just printed 'Configuration successfully updated!' without explicitly showing what changed). 