### PR TITLE
Fix registry deps

### DIFF
--- a/packages/cli/src/commands/socket-add.js
+++ b/packages/cli/src/commands/socket-add.js
@@ -26,11 +26,11 @@ export default class SocketAdd {
       if (cmd.socket) {
         // Socket dependency
         this.socket = await this.Socket.get(cmd.socket)
-        return this.socket.addDependency(socketFromRegistry)
+        await this.socket.addDependency(socketFromRegistry)
+      } else {
+        // Project dependency
+        await this.Socket.add(socketFromRegistry)
       }
-
-      // Project dependency
-      await this.Socket.add(socketFromRegistry)
 
       const status = format.grey('socket added:')
       const name = format.cyan(this.socketFromRegistry.name)
@@ -61,7 +61,11 @@ export default class SocketAdd {
         }
       } else {
         echo()
-        echo(`${format.red(err)}\n`)
+        if(err.message) {
+          echo(`${format.red(err.message)}\n`)
+        } else {
+          echo(`${format.red(err)}\n`)
+        }
         echo()
       }
     }

--- a/packages/cli/src/utils/sockets/sockets.js
+++ b/packages/cli/src/utils/sockets/sockets.js
@@ -1017,7 +1017,7 @@ class Socket {
         await Registry.getSocket(this)
         const fileName = path.join(session.getBuildPath(), `${this.name}.zip`)
 
-        await new Promise(async (resolve, reject) => {
+        await new Promise((resolve, reject) => {
           fs.createReadStream(fileName)
             .pipe(unzip.Extract({ path: this.getSocketPath() }))
             .on('close', async () => {

--- a/packages/cli/src/utils/sockets/sockets.js
+++ b/packages/cli/src/utils/sockets/sockets.js
@@ -329,11 +329,10 @@ class Socket {
     debug(`Getting Socket: ${socketName}`)
     const socket = Socket.getLocal(socketName)
     const loadedSocket = await socket.loadRemote()
-    await loadedSocket.getDepsRegistrySockets()
-
     if (!socket.existLocally) {
       await socket.loadFromRegistry()
     }
+    await loadedSocket.getDepsRegistrySockets()
     return socket
   }
 
@@ -564,7 +563,7 @@ class Socket {
 
   getSocketNodeModulesChecksum () {
     debug('getSocketNodeModulesChecksum')
-    return hashdirectory.sync(path.join(this.socketPath, '.dist', 'node_modules'))
+    return hashdirectory.sync(path.join(this.getSocketPath(), '.dist', 'node_modules'))
   }
 
   getSocketConfigFile () {
@@ -1018,12 +1017,19 @@ class Socket {
         await Registry.getSocket(this)
         const fileName = path.join(session.getBuildPath(), `${this.name}.zip`)
 
-        await new Promise((resolve, reject) => {
+        await new Promise(async (resolve, reject) => {
           fs.createReadStream(fileName)
             .pipe(unzip.Extract({ path: this.getSocketPath() }))
-            .on('close', () => {
+            .on('close', async () => {
               debug('Unzip finished')
-              resolve()
+
+              // Build registry socket.
+              try {
+                await this.build()
+              } catch(e) {
+                return reject(e)
+              }
+              return resolve()
             })
         })
       }


### PR DESCRIPTION
When cli pulls in registry dep it does not run npm install, which crashes cli on npm run build step of registry dependency. Also cli does not follow dependencies declared in socket.yml of registry dependency. This PR fixes those 2 issues.