### PR TITLE
Load 500 records per request instead of default 100

### DIFF
--- a/packages/lib-js-core/src/query-builder.js
+++ b/packages/lib-js-core/src/query-builder.js
@@ -3,6 +3,7 @@ import logger from 'debug'
 import pjson from '../package.json'
 import nodeFetch from 'node-fetch'
 import {checkStatus, parseJSON} from './utils'
+import {MAX_PAGE_SIZE} from './data'
 
 const debug = logger('core:query-builder')
 
@@ -80,7 +81,9 @@ export default class QueryBuilder {
   }
 
   get query () {
-    return this._query || {}
+    return this._query || {
+      page_size: MAX_PAGE_SIZE
+    }
   }
 
   get queries () {

--- a/packages/lib-js-core/src/users.js
+++ b/packages/lib-js-core/src/users.js
@@ -16,14 +16,23 @@ class Users extends Data {
     return query ? `${url}?${query}` : url
   }
 
+  authUrl () {
+    const {instanceName} = this.instance
+    const url = `${this._getInstanceURL(instanceName)}/users/auth/`
+    const query = querystring.stringify(this.query)
+
+    return query ? `${url}?${query}` : url
+  }
+
   login ({username, password}) {
     const fetch = this.fetch.bind(this)
+
     return new Promise((resolve, reject) => {
       const options = {
         method: 'POST',
         body: JSON.stringify({ username, password })
       }
-      fetch(`${this.url()}auth/`, options)
+      fetch(`${this.authUrl()}`, options)
         .then(res => resolve(res))
         .catch(err => reject(err))
     })

--- a/packages/lib-js-core/test/unit/users.js
+++ b/packages/lib-js-core/test/unit/users.js
@@ -25,6 +25,9 @@ describe('Users', () => {
     it('should list users', () => {
       api
         .get(`/v3/instances/${instanceName}/users/`)
+        .query({
+          page_size: 500,
+        })
         .reply(200, {objects: [{id: 1}, {id: 2}]})
 
       return users.list().should.become([{id: 1}, {id: 2}])


### PR DESCRIPTION
This query will now execute 3 requests, each will take 500, 500 and 400 objects per request. Previously it would take 14 request(100 objects per each).
```
// We have 1400 posts in db
data.post.list() 
```

