### PR TITLE
Export server as named Core export

### DIFF
--- a/packages/lib-js-core/src/context.ts
+++ b/packages/lib-js-core/src/context.ts
@@ -1,4 +1,4 @@
-export interface SyncanoContext<Args = {}> {
+export interface Context<Args = {}> {
   args: Args
   meta: Meta
   config: Config

--- a/packages/lib-js-core/src/index.ts
+++ b/packages/lib-js-core/src/index.ts
@@ -20,7 +20,8 @@ export {
   Trace
 } from './types'
 export {DataClass} from './data'
-export {SyncanoContext} from './context'
+export {Server as Core}
+export {Context} from './context'
+export default Server
 module.exports = Server
 module.exports.default = Server
-export default Server


### PR DESCRIPTION
This change will allow to:

```js
import * as S from '@syncano/core'

const s = new S.Core(ctx)
```

This will help to avoid using default import