### PR TITLE
Bugfix: Environment var names for socket configuration are parsed properly

### DIFF
--- a/packages/cli/src/utils/sockets/sockets.js
+++ b/packages/cli/src/utils/sockets/sockets.js
@@ -1035,8 +1035,8 @@ class Socket {
   }
 
   getConfigOptionFromEnv (optionName) {
-    const socketVarName = this.name.replace(/\-/g, '_').toUpperCase()
-    const optionVarName = optionName.replace(/\-/g, '_').toUpperCase()
+    const socketVarName = this.name.replace(/-/g, '_').toUpperCase()
+    const optionVarName = optionName.replace(/-/g, '_').toUpperCase()
     return process.env[`${socketVarName}__${optionVarName}`] ||
       process.env[`${socketVarName}_${optionVarName}`]
   }

--- a/packages/cli/src/utils/sockets/sockets.js
+++ b/packages/cli/src/utils/sockets/sockets.js
@@ -1035,8 +1035,8 @@ class Socket {
   }
 
   getConfigOptionFromEnv (optionName) {
-    const socketVarName = this.name.replace('-', '_').toUpperCase()
-    const optionVarName = optionName.replace('-', '_').toUpperCase()
+    const socketVarName = this.name.replace(/\-/g, '_').toUpperCase()
+    const optionVarName = optionName.replace(/\-/g, '_').toUpperCase()
     return process.env[`${socketVarName}__${optionVarName}`] ||
       process.env[`${socketVarName}_${optionVarName}`]
   }


### PR DESCRIPTION
Before: 
`VAR` variable requested for `foo-bar-xyz` socket is looked up by `FOO_BAR-XYZ_VAR` (invalid)

After:
`VAR` variable requested for `foo-bar-xyz` socket is looked up by `FOO_BAR_XYZ_VAR` (valid)
