### PR TITLE
Use v3 for users fetched as related model - "with" method

### DIFF
--- a/packages/lib-js-core/src/data.ts
+++ b/packages/lib-js-core/src/data.ts
@@ -843,7 +843,7 @@ export class DataClass<ClassSchema = {
 
           if (target === 'user') {
             load._url = `${this.getInstanceURL(
-              this.instance.instanceName
+              this.instance.instanceName, 'v3'
             )}/users/`
           }
 

--- a/packages/lib-js-core/test/unit/data.ts
+++ b/packages/lib-js-core/test/unit/data.ts
@@ -566,7 +566,7 @@ describe('Data', () => {
             }
           ]
         })
-        .get(`/v2/instances/${instanceName}/users/`)
+        .get(`/v3/instances/${instanceName}/users/`)
         .query({
           query: JSON.stringify({id: {_in: [1]}}),
           page_size: 500


### PR DESCRIPTION
`users.list()` -> request with v3 👌 
`data.testimonial.with('author').list()` -> request for testimonials will go with v3 but for author column which is a reference to user class - v2 will be used. This PR fixes that.